### PR TITLE
When loading fixtures, do not trigger audits.

### DIFF
--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -31,12 +31,12 @@ def audit_m2m_change(sender, **kwargs):
 
 
 def audit_post_save(sender, **kwargs):
-    if kwargs['created']:
+    if kwargs['created'] and not kwargs.get('raw', False):
         save_audit(kwargs['instance'], Audit.ADD)
 
 
 def audit_pre_save(sender, **kwargs):
-    if kwargs['instance'].pk:
+    if kwargs['instance'].pk and not kwargs.get('raw', False):
         save_audit(kwargs['instance'], Audit.CHANGE)
 
 


### PR DESCRIPTION
When testing in Django, the audits are automatically triggered. This allows users to load fixtures without unnecessarily triggering audits.

See the keyward argument 'raw' here:
https://docs.djangoproject.com/en/1.6/ref/signals/#django.db.models.signals.pre_save
