### PR TITLE
Added a convenience manager method

### DIFF
--- a/simple_audit/managers.py
+++ b/simple_audit/managers.py
@@ -1,0 +1,25 @@
+from django.db import models
+from django.db.models.query import QuerySet
+from django.contrib.contenttypes.models import ContentType
+
+
+class AuditQuerySet(QuerySet):
+    def _get_content_type(self, obj):
+        return ContentType.objects.get_for_model(obj)
+
+    def for_(self, obj):
+        return self.filter(
+            content_type=self._get_content_type(obj),
+            object_id=obj.id
+        )
+
+
+class AuditManager(models.Manager):
+    def get_query_set(self):
+        return AuditQuerySet(self.model)
+
+    def __getattr__(self, attr, *args):
+        # see https://code.djangoproject.com/ticket/15062 for details
+        if attr.startswith("_"):
+            raise AttributeError
+        return getattr(self.get_query_set(), attr, *args)

--- a/simple_audit/models.py
+++ b/simple_audit/models.py
@@ -6,6 +6,8 @@ import uuid
 
 from django.db import models
 from django.contrib.auth.models import User
+from .managers import AuditManager
+
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.utils.translation import ugettext_lazy as _
@@ -44,6 +46,8 @@ class Audit(models.Model):
     audit_request = models.ForeignKey("AuditRequest", null=True)
     description = models.TextField()
     obj_description = models.CharField(max_length=100, db_index=True, null=True, blank=True)
+
+    objects = AuditManager()
 
     @property
     def operation_name(self):


### PR DESCRIPTION
Allows you to query the Audit model using neat syntax, e.g. `Audit.objects.for_(ModelName).all()`
