### PR TITLE
audit_m2m_change handler on fields which have intermediate m2m models

### DIFF
--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -87,7 +87,9 @@ def register(*my_models):
                     for m2m in m2ms:
                         try:
                             sender_m2m = getattr(model, m2m[0].name).through
-                            models.signals.m2m_changed.connect(audit_m2m_change, sender=sender_m2m)
+                            if sender_m2m.__name__ == "{}_{}".format(model.__name__, m2m[0].name):
+                                models.signals.m2m_changed.connect(audit_m2m_change, sender=sender_m2m)
+                                LOG.debug("Attached signal to: %s" % sender_m2m)
                         except Exception, e:
                             LOG.warning("could not create signal for m2m field: %s" % e)
 


### PR DESCRIPTION
The m2m_changed signal does not fire correctly for these fields

see: https://code.djangoproject.com/ticket/13757
