### PR TITLE
Add .get_queryset to AuditManager

### DIFF
--- a/simple_audit/managers.py
+++ b/simple_audit/managers.py
@@ -16,10 +16,13 @@ class AuditQuerySet(QuerySet):
 
 class AuditManager(models.Manager):
     def get_query_set(self):
+        return self.get_queryset()
+
+    def get_queryset(self):
         return AuditQuerySet(self.model)
 
     def __getattr__(self, attr, *args):
         # see https://code.djangoproject.com/ticket/15062 for details
         if attr.startswith("_"):
             raise AttributeError
-        return getattr(self.get_query_set(), attr, *args)
+        return getattr(self.get_queryset(), attr, *args)


### PR DESCRIPTION
Django 1.6 [deprecates](https://docs.djangoproject.com/en/1.6/releases/1.6/#get-query-set-and-similar-methods-renamed-to-get-queryset) `.get_query_set`, `.queryset` and other
attributes in favor of `.get_queryset`. This change maintains backwards
compatibility.