### PR TITLE
When loading fixtures, do not trigger audits.

### DIFF
--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -49,13 +49,13 @@ def audit_m2m_change(sender, **kwargs):
 
 
 def audit_post_save(sender, **kwargs):
-    if kwargs['created']:
+    if kwargs['created'] and not kwargs.get('raw', False):
         save_audit(kwargs['instance'], Audit.ADD)
 
 
 def audit_pre_save(sender, **kwargs):
     instance=kwargs.get('instance')
-    if instance.pk:
+    if instance.pk and not kwargs.get('raw', False):
         if settings.DJANGO_SIMPLE_AUDIT_M2M_FIELDS:
             if m2m_audit.get_m2m_fields_for(instance): #has m2m fields?
                 cache_key = get_cache_key_for_instance(instance)


### PR DESCRIPTION
When testing in Django, the audits are automatically triggered. This
allows users to load fixtures without unnecessarily triggering audits.

See the keyward argument 'raw' here:
https://docs.djangoproject.com/en/1.6/ref/signals/#django.db.models.signals.pre_save

Also see previous unmerged PR from October 2013, leandrosouza/django-simple-audit#6
