### PR TITLE
Fixing admin display Current Content when audited model was deleted

### DIFF
--- a/simple_audit/admin.py
+++ b/simple_audit/admin.py
@@ -54,7 +54,9 @@ class AuditAdmin(admin.ModelAdmin):
     audit_description.short_description = _("Description")
 
     def audit_content(self, audit):
-        obj_string = audit.obj_description or unicode(audit.content_object)
+        obj_string = audit.obj_description
+        if not obj_string and audit.content_type.model_class():
+            obj_string = unicode(audit.content_object)
 
         return "<a title='%(filter)s' href='%(base)s?content_type__id__exact=%(type_id)s&object_id__exact=%(id)s'>%(type)s: %(obj)s</a>" % {
             'filter': _("Click to filter"),


### PR DESCRIPTION
Hi,

I found this problem after a remove an useless model in my django app.

```
Traceback:
  File "/my/env/lib/python2.7/site-packages/simple_audit/admin.py", line 57, in audit_content
    obj_string = audit.obj_description or unicode(audit.content_object)
  File "/my/env/lib/python2.7/site-packages/django/contrib/contenttypes/generic.py", line 137, in __get__
    rel_obj = ct.get_object_for_this_type(pk=getattr(instance, self.fk_field))
  File "/my/env/lib/python2.7/site-packages/django/contrib/contenttypes/models.py", line 168, in get_object_for_this_type
    return self.model_class()._base_manager.using(self._state.db).get(**kwargs)
AttributeError: 'NoneType' object has no attribute '_base_manager'
```